### PR TITLE
Potential fix for code scanning alert no. 33: Uncontrolled data used in path expression

### DIFF
--- a/index.py
+++ b/index.py
@@ -54,8 +54,10 @@ async def index(lang_code: str) -> Response:
     user_dir = request.args.get("dir", "")
     if Path(user_dir).is_absolute():
         return abort(404)
-    directory = (safe_root / user_dir).resolve()
-    if safe_root not in directory.parents and directory != safe_root:
+    directory = safe_root.joinpath(user_dir).resolve()
+    try:
+        directory.relative_to(safe_root)
+    except ValueError:
         return abort(404)
     _ = get_translator(lang_code).gettext
     file_list = []

--- a/index.py
+++ b/index.py
@@ -50,8 +50,11 @@ async def index(lang_code: str) -> Response:
     }
     if lang_code not in valid_languages:
         return await download_file(lang_code)
-    safe_root = Path(__file__).resolve().parent / "downloads"
-    directory = (safe_root / request.args.get("dir", "")).resolve()
+    safe_root = (Path(__file__).resolve().parent / "downloads").resolve()
+    user_dir = request.args.get("dir", "")
+    if Path(user_dir).is_absolute():
+        return abort(404)
+    directory = (safe_root / user_dir).resolve()
     if safe_root not in directory.parents and directory != safe_root:
         return abort(404)
     _ = get_translator(lang_code).gettext


### PR DESCRIPTION
Potential fix for [https://github.com/robonamari/dirlotix.py/security/code-scanning/33](https://github.com/robonamari/dirlotix.py/security/code-scanning/33)

Use a two-layer validation approach in `index.py` around line 54:

1. Read `dir` into a local variable.
2. Reject clearly unsafe forms early (absolute paths).
3. Build a normalized candidate path (`safe_root / user_dir` then `.resolve()`).
4. Keep/strengthen the existing “must stay under safe_root” containment check using normalized roots.

Best concrete fix (without changing functionality):  
- In `index()` replace direct inline use of `request.args.get("dir", "")` with a validated `user_dir`.
- Add an early check using `Path(user_dir).is_absolute()` and abort on true.
- Resolve both `safe_root` and candidate directory before comparison.
- Preserve existing behavior for valid relative subdirectories.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
