### PR TITLE
Potential fix for code scanning alert no. 35: Uncontrolled data used in path expression

### DIFF
--- a/index.py
+++ b/index.py
@@ -147,12 +147,14 @@ async def download_file(filename: str) -> Response:
     Returns:
         Response: A Flask response that initiates the file download if the file is valid, or an appropriate error response if the file is not found or access is forbidden.
     """
-    safe_root = Path(__file__).parent / "downloads"
+    safe_root = (Path(__file__).resolve().parent / "downloads").resolve()
     file_path = (safe_root / filename).resolve()
+    try:
+        file_path.relative_to(safe_root)
+    except ValueError:
+        return abort(403)
     if not file_path.is_file():
         return abort(404)
-    if safe_root not in file_path.parents:
-        return abort(403)
     ignore_files = set(os.getenv("IGNORE_FILES", "").split(","))
     for part in Path(filename).parts:
         if part in ignore_files:


### PR DESCRIPTION
Potential fix for [https://github.com/robonamari/dirlotix.py/security/code-scanning/35](https://github.com/robonamari/dirlotix.py/security/code-scanning/35)

Use strict canonical path validation against a resolved trusted root **before** any file access checks, and ensure both sides of the comparison are normalized in the same way.

Best fix in this snippet:
- In `download_file` (around lines 150–155), change `safe_root` to `Path(__file__).resolve().parent / "downloads"` and resolve it.
- Build `file_path` from this resolved root and user input, resolve it, then enforce containment with a robust check (using `relative_to` in a `try/except`).
- Only after containment passes, check `is_file()` and continue existing logic.

This preserves behavior while making the validation pattern explicit and resilient, and addresses both alert variants (`lang_code` flowing into `filename`, and direct `filename` input).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
