### PR TITLE
Potential fix for code scanning alert no. 42: Uncontrolled data used in path expression

### DIFF
--- a/index.py
+++ b/index.py
@@ -160,8 +160,11 @@ async def download_file(filename: str) -> Response:
         return abort(400)
     if ".." in Path(filename).parts:
         return abort(403)
-    file_path = (safe_root / filename).resolve()
-    if safe_root not in file_path.parents:
+    safe_path = safe_join(str(safe_root), filename)
+    if safe_path is None:
+        return abort(403)
+    file_path = Path(safe_path).resolve()
+    if file_path != safe_root and safe_root not in file_path.parents:
         return abort(403)
     ignore_files = set(os.getenv("IGNORE_FILES", "").split(","))
     for part in Path(filename).parts:


### PR DESCRIPTION
Potential fix for [https://github.com/robonamari/dirlotix.py/security/code-scanning/42](https://github.com/robonamari/dirlotix.py/security/code-scanning/42)

Use `werkzeug.security.safe_join` in `download_file` (as already done in `index`) so untrusted `filename` is never directly composed into a filesystem path expression via `safe_root / filename`.

Best fix in this file:
- In `index.py`, within `download_file` (around lines 158–165), replace:
  - `file_path = (safe_root / filename).resolve()`
  - parent check logic tied to that construction
- With:
  - `safe_path = safe_join(str(safe_root), filename)` and reject when `None`
  - then `file_path = Path(safe_path).resolve()`
  - keep a defensive containment check (`safe_root == file_path or safe_root in file_path.parents`)
- Keep existing behavior (same HTTP codes for invalid path vs forbidden where practical), and keep ignore-list and `is_file()` logic unchanged.

No new imports are needed because `safe_join` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
